### PR TITLE
Add support for multi-site entries

### DIFF
--- a/src/Policies/EntryPolicy.php
+++ b/src/Policies/EntryPolicy.php
@@ -13,7 +13,7 @@ class EntryPolicy extends \Statamic\Policies\EntryPolicy
     {
         // If user cannot view other authors' entries, check if the entry belongs to the current user.
         if (!$user->isSuper() && !$user->hasPermission("view other authors' {$entry->collectionHandle()} entries")) {
-            return $user->id === $entry->augmentedValue('author')?->raw());
+            return $user->id === $entry->augmentedValue('author')?->raw();
         }
 
         // Else continue with the default permissions

--- a/src/Policies/EntryPolicy.php
+++ b/src/Policies/EntryPolicy.php
@@ -13,7 +13,7 @@ class EntryPolicy extends \Statamic\Policies\EntryPolicy
     {
         // If user cannot view other authors' entries, check if the entry belongs to the current user.
         if (!$user->isSuper() && !$user->hasPermission("view other authors' {$entry->collectionHandle()} entries")) {
-            return $user->id === $entry->get('author');
+            return $user->id === $entry->augmentedValue('author')?->raw());
         }
 
         // Else continue with the default permissions


### PR DESCRIPTION
Currently, multi-site entries cannot be created because the author field on the derived entry is always empty. By using `augmentedValue` instead of just `get`, the author field does not have to be filled by the current entry directly, but can also be inherited from an origin entry.